### PR TITLE
Fixed compare errors.

### DIFF
--- a/safe_numerics/include/safe_range.hpp
+++ b/safe_numerics/include/safe_range.hpp
@@ -508,7 +508,7 @@ typename boost::enable_if<
     bool
 >::type
 operator<(const T & lhs, const safe_range_base<Stored, Derived> & rhs) {
-    return rhs >= lhs;
+    return rhs > lhs;
 }
 template<class T, class Stored, class Derived>
 typename boost::enable_if<
@@ -516,7 +516,7 @@ typename boost::enable_if<
     bool
 >::type
 inline operator>(const T & lhs, const safe_range_base<Stored, Derived> & rhs) {
-    return rhs <= lhs;
+    return rhs < lhs;
 }
 template<class T, class Stored, class Derived>
 typename boost::enable_if<
@@ -540,7 +540,7 @@ typename boost::enable_if<
     bool
 >::type
 inline operator>=(const T & lhs, const safe_range_base<Stored, Derived> & rhs) {
-    return rhs < lhs;
+    return rhs <= lhs;
 }
 template<class T, class Stored, class Derived>
 typename boost::enable_if<
@@ -548,7 +548,7 @@ typename boost::enable_if<
     bool
 >::type
 inline operator<=(const T & lhs, const safe_range_base<Stored, Derived> & rhs) {
-    return  rhs > lhs;
+    return  rhs >= lhs;
 }
 
 // addition

--- a/safe_numerics/test/test_compare.cpp
+++ b/safe_numerics/test/test_compare.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2013 Ruslan Baratov
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "../include/safe_integer.hpp"
+#include <cassert>
+
+template <class T>
+void test_equal(T test_val) {
+  namespace num = boost::numeric;
+  num::safe<T> x = test_val;
+  num::safe<T> y = test_val;
+  assert(x == y);
+  assert(x >= y);
+  assert(x <= y);
+  assert(!(x < y));
+  assert(!(x > y));
+}
+
+template <class T>
+void test_non_equal(T test_val) {
+  namespace num = boost::numeric;
+  num::safe<T> x(test_val);
+  num::safe<T> y(test_val + 1);
+  assert(x != y);
+  assert(!(x >= y));
+  assert(x <= y);
+  assert(x < y);
+  assert(!(x > y));
+}
+
+int main() {
+  test_equal<unsigned>(0);
+  test_equal<unsigned>(3);
+  test_equal<unsigned short>(14);
+
+  test_equal<int>(3);
+
+  test_equal<uint64_t>(45);
+
+  test_non_equal<unsigned>(342);
+  test_non_equal<signed char>(33);
+  test_non_equal<int32_t>(-988);
+}


### PR DESCRIPTION
When values are equal operators: 'operator<', 'operator>', 'operator>=' and
'operator<=' produce incorrect result. Add test test_compare.cpp.
