### PR TITLE
Support for -fno-exceptions

### DIFF
--- a/include/exception_policies.hpp
+++ b/include/exception_policies.hpp
@@ -74,19 +74,19 @@ struct throw_exception {
     static void no_error(const char *) {
     }
     static void unintialized_error(const char * message) {
-        boost::throw_exception((message));
+        boost::throw_exception(std::invalid_argument(message));
     }
     static void overflow_error(const char * message) {
-        boost::throw_exception((message));
+        boost::throw_exception(std::overflow_error(message));
     }
     static void underflow_error(const char * message) {
-        boost::throw_exception((message));
+        boost::throw_exception(std::underflow_error(message));
     }
     static void range_error(const char * message) {
-        boost::throw_exception((message));
+        boost::throw_exception(std::range_error(message));
     }
     static void domain_error(const char * message) {
-        boost::throw_exception((message));
+        boost::throw_exception(std::domain_error(message));
     }
 };
 

--- a/include/exception_policies.hpp
+++ b/include/exception_policies.hpp
@@ -16,6 +16,7 @@
 #include <functional>
 #include <type_traits> // is_base_of, is_same
 #include <exception>
+#include <boost/throw_exception.hpp>
 
 namespace boost {
 namespace numeric {
@@ -73,19 +74,19 @@ struct throw_exception {
     static void no_error(const char *) {
     }
     static void unintialized_error(const char * message) {
-        throw std::invalid_argument(message);
+        boost::throw_exception((message));
     }
     static void overflow_error(const char * message) {
-        throw std::overflow_error(message);
+        boost::throw_exception((message));
     }
     static void underflow_error(const char * message) {
-        throw std::underflow_error(message);
+        boost::throw_exception((message));
     }
     static void range_error(const char * message) {
-        throw std::range_error(message);
+        boost::throw_exception((message));
     }
     static void domain_error(const char * message) {
-        throw std::domain_error(message);
+        boost::throw_exception((message));
     }
 };
 


### PR DESCRIPTION
Suppose I want to compile a program with exceptions disabled, on gcc/clang, I use flag `-fno-exceptions`. I can use a custom exception policy for `safe<int>` but that does not help me because in `-fno-exceptions` mode, compiler reports an error when it sees keyword `throw` anywhere, even in the policy I do not use. The solution for this is to use [Boost.ThrowException](http://www.boost.org/doc/libs/1_63_0/libs/exception/doc/boost_throw_exception_hpp.html) library.