### PR TITLE
fix safe_format includes

### DIFF
--- a/example/safe_format.hpp
+++ b/example/safe_format.hpp
@@ -15,6 +15,7 @@
 
 #include <ostream>
 #include <typeinfo>
+#include <limits>
 
 #include <boost/core/demangle.hpp>
 #include <boost/safe_numerics/safe_common.hpp>


### PR DESCRIPTION
std::numeric_limits requires `<limits>`

Without the include safe_format.hpp will not compile, as can be seen here: https://godbolt.org/z/5K73PGd7h