### PR TITLE
fix interval<R>::excludes() comment

### DIFF
--- a/include/boost/safe_numerics/interval.hpp
+++ b/include/boost/safe_numerics/interval.hpp
@@ -61,7 +61,7 @@ struct interval {
         return u >= t.u && l <= t.l;
     }
 
-    // return true if this interval contains the given point
+    // return true if this interval excludes the given point
     constexpr tribool excludes(const R & t) const {
         return t < l || t > u;
     }


### PR DESCRIPTION
The comment of "constexpr tribool excludes(const R & t) const" function is wrong.
Maybe the original comment is just copied from the "includes" function and forgot to make a correction.
So I fix the typo.