### PR TITLE
Fix typo in checked_float.hpp

### DIFF
--- a/include/boost/safe_numerics/checked_float.hpp
+++ b/include/boost/safe_numerics/checked_float.hpp
@@ -61,7 +61,7 @@ struct heterogeneous_checked_operation<
     F,
     typename std::enable_if<
         std::is_floating_point<R>::value
-        && std::is_integralt<T>::value
+        && std::is_integral<T>::value
     >::type
 >{
     constexpr static checked_result<R>


### PR DESCRIPTION
Just found this and am surprised CI and tests didn't run into this. Maybe this is not tested?